### PR TITLE
Add S3 Terraform Module

### DIFF
--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -13,3 +13,11 @@ locals {
     Provisioner = "terraform"
   }
 }
+
+module "static_objects" {
+  source = "../../modules/s3"
+
+  default_tags = local.default_tags
+  name_prefix  = local.name_prefix
+  bucket_name  = "spokanerust-static-objects"
+}

--- a/infra/modules/s3/main.tf
+++ b/infra/modules/s3/main.tf
@@ -1,0 +1,15 @@
+locals {
+  default_tags = var.default_tags
+  name_prefix  = var.name_prefix
+
+  bucket_name = "s3-${local.name_prefix}-${var.bucket_name}"
+}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = local.bucket_name
+
+  tags = merge(
+    local.default_tags,
+    { Name = local.bucket_name }
+  )
+}

--- a/infra/modules/s3/variables.tf
+++ b/infra/modules/s3/variables.tf
@@ -1,0 +1,16 @@
+## GLOBAL VARIABLES ##
+variable "default_tags" {
+  type        = map(string)
+  description = "A map of tags to apply to all resources"
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "A prefix to apply to all resource names"
+}
+
+## MODULE VARIABLES ##
+variable "bucket_name" {
+  type        = string
+  description = "The name of the S3 bucket"
+}


### PR DESCRIPTION
Adds S3 to store static objects to use in the Rust website.